### PR TITLE
fix permission read_file_perms not defined fore fuseblk:file

### DIFF
--- a/audio_amplifier/audio_amplifier.c
+++ b/audio_amplifier/audio_amplifier.c
@@ -166,33 +166,6 @@ static int amp_enable_output_devices(struct amplifier_device *device, uint32_t d
     return 0;
 }
 
-    switch (devices) {
-        case SND_DEVICE_OUT_SPEAKER:
-        case SND_DEVICE_OUT_SPEAKER_REVERSE:
-            pthread_mutex_lock(&tfa9890->amp_update);
-            tfa9890_update_amp(tfa9890, tfa9890->state.in_stream, tfa9890->state.in_call,
-                               tfa9890->state.amp_device, tfa9890->state.amp_mode);
-            pthread_mutex_unlock(&tfa9890->amp_update);
-            break;
-        case SND_DEVICE_OUT_VOICE_SPEAKER:
-        case SND_DEVICE_OUT_HANDSET:
-        case SND_DEVICE_OUT_VOICE_HANDSET:
-            pthread_mutex_lock(&tfa9890->amp_update);
-            tfa9890_update_amp(tfa9890, tfa9890->state.in_stream, enable,
-                               tfa9890->state.amp_device, tfa9890->state.amp_mode);
-            pthread_mutex_unlock(&tfa9890->amp_update);
-            break;
-        default:
-            ALOGE("%s: Unandled device %d\n", __func__, devices);
-            pthread_mutex_lock(&tfa9890->amp_update);
-            tfa9890_update_amp(tfa9890, tfa9890->state.in_stream, tfa9890->state.in_call,
-                               tfa9890->state.amp_device, tfa9890->state.amp_mode);
-            pthread_mutex_unlock(&tfa9890->amp_update);
-            break;
-    }
-    return 0;
-}
-
 static int tfa9890_set_mode(struct amplifier_device *device, audio_mode_t mode) {
     ALOGD("%s: %u\n", __func__, mode);
     tfa9890_device_t *tfa9890 = (tfa9890_device_t*) device;

--- a/sepolicy/untrusted_app.te
+++ b/sepolicy/untrusted_app.te
@@ -2,7 +2,7 @@ allow untrusted_app sysfs:file getattr;
 allow untrusted_app sysfs:file open;
 allow untrusted_app sysfs:file read; 
 
-allow untrusted_app fuseblk:file read_file_perms;
+allow untrusted_app fuseblk:file { open getattr read ioctl lock };
 allow untrusted_app storage_stub_file:dir getattr;
 allow untrusted_app sysfs:file read;
 allow untrusted_app app_data_file:file open;


### PR DESCRIPTION
could not build due to following error :

```
loading policy configuration from out/target/product/axon7/obj/ETC/sepolicy_intermediates/policy.conf
device/zte/axon7/sepolicy/untrusted_app.te:6:ERROR 'permission read_file_perms is not defined for class file' at token ';' on line 20484:
allow untrusted_app fuseblk:file read_file_perms;
```
